### PR TITLE
Fixed travis build error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: "node_js"
 node_js:
   - "0.10"
-  - "0.8"
 before_script:
   - npm install -g bower
   - bower install

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "CONTRIBUTING.md"
   ],
   "devDependencies": {
-    "chai": "~1.7.2",
-    "flight": "~1.1.0"
+    "chai": "~1.9.1",
+    "flight": "~1.1.4"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,23 +8,13 @@ module.exports = function (config) {
     // base path, that will be used to resolve files and exclude
     basePath: '',
 
-    frameworks: ['mocha'],
+    frameworks: ['requirejs', 'mocha', 'sinon'],
 
     // list of files / patterns to load in the browser
     files: [
-      'bower_components/chai/chai.js',
-      'bower_components/es5-shim/es5-shim.js',
-      'bower_components/es5-shim/es5-sham.js',
-      'bower_components/jquery/jquery.js',
-      'node_modules/sinon/pkg/sinon.js',
-
       'lib/mocha-flight.js',
 
-      // hack to load RequireJS after the shim libs
-      'node_modules/karma-requirejs/lib/require.js',
-      'node_modules/karma-requirejs/lib/adapter.js',
-
-      {pattern: 'bower_components/flight/**/*.js', included: false},
+      {pattern: 'bower_components/**/*.js', included: false},
       {pattern: 'test/mock/*.js', included: false},
       {pattern: 'test/spec/*.js', included: false},
 
@@ -48,15 +38,6 @@ module.exports = function (config) {
 
     // Auto run tests on start (when browsers are captured) and exit
     // CLI --single-run --no-single-run
-    singleRun: false,
-
-    plugins: [
-      'karma-mocha',
-      'karma-requirejs',
-      'karma-chrome-launcher',
-      'karma-firefox-launcher',
-      'karma-ie-launcher',
-      'karma-safari-launcher'
-    ]
+    singleRun: false
   });
 };

--- a/package.json
+++ b/package.json
@@ -2,17 +2,18 @@
   "name": "mocha-flight",
   "version": "0.3.0",
   "devDependencies": {
-    "karma": "~0.10.1",
-    "karma-mocha": "~0.1",
-    "karma-requirejs": "~0.1.0",
-    "karma-chrome-launcher": "~0.1.0",
-    "karma-ie-launcher": "~0.1.1",
-    "karma-firefox-launcher": "~0.1.0",
+    "karma": "~0.12.16",
+    "karma-mocha": "~0.1.4",
+    "karma-requirejs": "~0.2.2",
+    "karma-chai-plugins": "~0.2.1",
+    "karma-sinon": "~1.0.0",
+    "karma-chrome-launcher": "~0.1.4",
+    "karma-ie-launcher": "~0.1.3",
+    "karma-firefox-launcher": "~0.1.3",
     "karma-phantomjs-launcher": "~0.1.0",
-    "karma-safari-launcher": "~0.1.1",
-    "sinon": "*"
+    "karma-safari-launcher": "~0.1.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/karma start --browsers Firefox --single-run"
+    "test": "./node_modules/karma/bin/karma start --browsers Firefox --single-run"
   }
 }

--- a/test/spec/describe_component.spec.js
+++ b/test/spec/describe_component.spec.js
@@ -1,9 +1,9 @@
-/*global describeComponent, setupComponent, chai*/
+/*global describeComponent, setupComponent*/
 
 define(function (require) {
   'use strict';
 
-  var expect = chai.expect;
+  var expect = require('chai').expect;
   var defineComponent = require('flight/lib/component');
   var Example = require('mock/example');
 

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -1,9 +1,5 @@
 'use strict';
 
-var tests = Object.keys(window.__karma__.files).filter(function (file) {
-  return (/\.spec\.js$/.test(file));
-});
-
 mocha.setup('mocha-flight');
 
 requirejs.config({
@@ -11,12 +7,23 @@ requirejs.config({
   baseUrl: '/base',
 
   paths: {
+    'es5-shim': 'bower_components/es5-shim/es5-shim',
+    'es5-sham': 'bower_components/es5-shim/es5-sham',
+    'jquery': 'bower_components/jquery/dist/jquery',
     'flight': 'bower_components/flight',
+    'chai': 'bower_components/chai/chai',
     'mock': 'test/mock'
   },
 
-  // ask Require.js to load these files (all our tests)
-  deps: tests,
+  // ask Require.js to load these files (all dependent libs and our tests)
+  deps: (function () {
+    var libs = ['es5-shim', 'es5-sham', 'jquery'],
+      tests = Object.keys(window.__karma__.files).filter(function (file) {
+        return (/\.spec\.js$/.test(file));
+      });
+
+    return Array.prototype.concat(libs, tests);
+  }()),
 
   // start test run, once Require.js is done
   callback: window.__karma__.start


### PR DESCRIPTION
There were some dev dependencies updates that broke npm install process. In effect travis build was failing. I fixed all that issues.
I also updated most of dev dependencies and added grunt task which will simplify that in the future.

Karma is not updated to 0.12.x because it doesn't work with Travis command line:

```
 mocha-flight@0.3.0 test /home/travis/build/gziolo/mocha-flight
> karma start --browsers Firefox --single-run
sh: 1: karma: not found
```

I also removed support for node 0.8.x as latest dev dependencies doesn't work in this env.
