### PR TITLE
Updated to flight v1.2.0 and updated mock example component.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
   ],
   "devDependencies": {
     "chai": "~1.9.1",
-    "flight": "~1.1.4"
+    "flight": "~1.2.0"
   }
 }

--- a/test/mock/example.js
+++ b/test/mock/example.js
@@ -4,7 +4,7 @@ define(function (require) {
   var defineComponent = require('flight/lib/component');
 
   function Example() {
-    this.defaultAttrs({
+    this.attributes({
       param: 'defaultParam'
     });
   }


### PR DESCRIPTION
This commit updates the bower.json to install flight v1.2.0 instead of v1.1.4. It also updates the mock example component to use `this.attributes()` instead of `this.defaultAttrs()`.
