### PR TITLE
Fix for multiple test suites in the same require context (fixes #15)

### DIFF
--- a/lib/mocha-flight.js
+++ b/lib/mocha-flight.js
@@ -232,12 +232,14 @@ Mocha.interfaces['mocha-flight'] = (function () {
         var depth = 0;
         var ctx;
 
-        while (typeof suite.ctx.Component === 'undefined' && depth < 10) {
-          suite = suite.suites[0];
-          depth++;
+        function findContext (suite) {
+          if ( suite.ctx.hasOwnProperty('Component') && typeof suite.ctx.Component === 'function' ) {
+            ctx = suite.ctx;
+          }
+          suite.suites.forEach( findContext );
         }
 
-        ctx = suite.ctx;
+        findContext( suite );
 
         if (ctx.component) {
           ctx.component.teardown();

--- a/test/mock/other-example.js
+++ b/test/mock/other-example.js
@@ -1,0 +1,13 @@
+define(function (require) {
+  'use strict';
+
+  var defineComponent = require('flight/lib/component');
+
+  function OtherExample() {
+    this.attributes({
+      param: 'otherParam'
+    });
+  }
+
+  return defineComponent(OtherExample);
+});

--- a/test/spec/describe_component.spec.js
+++ b/test/spec/describe_component.spec.js
@@ -6,6 +6,7 @@ define(function (require) {
   var expect = require('chai').expect;
   var defineComponent = require('flight/lib/component');
   var Example = require('mock/example');
+  var OtherExample = require('mock/other-example');
 
   describeComponent('mock/example', function () {
     describe('this.Component', function () {
@@ -144,6 +145,22 @@ define(function (require) {
           this.Component.prototype.teardown.restore();
         }
       });
+    });
+  });
+
+  describeComponent('mock/other-example', function () {
+    it('should support test suites for different components', function () {
+      setupComponent();
+      expect(this.Component).to.equal(OtherExample);
+      expect(this.component.attr.param).to.equal('otherParam');
+    });
+  });
+
+  describeComponent('mock/example', function () {
+    it('should support multiple test suites on the same component', function () {
+      setupComponent();
+      expect(this.Component).to.equal(Example);
+      expect(this.component).to.be.an.instanceof(Example);
     });
   });
 });


### PR DESCRIPTION
The context selection in setupComponent() didn't allow for multiple
top-level test suites. This commit swaps out the logic used to find the
context with a recursive strategy. By doing so, we can support multiple
top-level test suites for the same component.