### PR TITLE
Add initialization method to allow controll over when triggering initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ describeMixin('path/to/mixin', function () {
 
 You will need to use a library like [sinon.js](https://github.com/cjohansen/Sinon.JS).
 
+```javascript
+describeComponent('path/to/component', function () {
+  beforeEach(function () {
+    setupComponent();
+  });
+
+  it('should do x', function () {
+    sinon.stub(this.component, 'method');
+
+    // You need to initialize the component after stubbing the function so the
+    // event will be bound and call the stubbed callback function
+    initializeComponent();
+
+    $(document).trigger('EVENT_NAME');
+    this.component.method.calledOnce.should.be.true;
+    done();
+  });
+});
+```
+
 ### setupComponent
 
 ```javascript

--- a/lib/mocha-flight.js
+++ b/lib/mocha-flight.js
@@ -228,18 +228,7 @@ Mocha.interfaces['mocha-flight'] = (function () {
        * @param options {Options} (Optional)
        */
       context.setupComponent = function (fixture, options) {
-        var suite = suites[0];
-        var depth = 0;
-        var ctx;
-
-        function findContext (suite) {
-          if ( suite.ctx.hasOwnProperty('Component') && typeof suite.ctx.Component === 'function' ) {
-            ctx = suite.ctx;
-          }
-          suite.suites.forEach( findContext );
-        }
-
-        findContext( suite );
+        var ctx = getContext();
 
         if (ctx.component) {
           ctx.component.teardown();
@@ -250,16 +239,49 @@ Mocha.interfaces['mocha-flight'] = (function () {
           ctx.$node = $(fixture);
         } else {
           ctx.$node = $('<div />');
-          options = fixture;
           fixture = null;
         }
+
+        if (typeof options !== 'undefined') {
+          ctx.options = options;
+        } else {
+          ctx.options = {};
+          options = undefined;
+        }
+
         ctx.$node.addClass('component-root');
         $('body').append(ctx.$node);
-
-        options = typeof options === 'undefined' ? {} : options;
-
-        ctx.component = (new ctx.Component()).initialize(ctx.$node, options);
+        ctx.component = new ctx.Component();
       };
+
+
+      /**
+       *
+       * Initialize the component
+       *
+       */
+
+      context.initializeComponent = function () {
+        var ctx = getContext();
+
+        ctx.component.initialize(ctx.$node, ctx.options);
+      };
+
+      function getContext() {
+        var suite = suites[0];
+        var ctx;
+
+        function findContext (suite) {
+          if ( suite.ctx.hasOwnProperty('Component') && typeof suite.ctx.Component === 'function' ) {
+            ctx = suite.ctx;
+          }
+          suite.suites.forEach( findContext );
+        }
+
+        findContext(suite);
+
+        return ctx;
+      }
     });
   };
 }).call(this);

--- a/lib/mocha-flight.js
+++ b/lib/mocha-flight.js
@@ -239,6 +239,7 @@ Mocha.interfaces['mocha-flight'] = (function () {
           ctx.$node = $(fixture);
         } else {
           ctx.$node = $('<div />');
+          options = fixture;
           fixture = null;
         }
 

--- a/test/mock/example.js
+++ b/test/mock/example.js
@@ -7,6 +7,15 @@ define(function (require) {
     this.attributes({
       param: 'defaultParam'
     });
+
+    this.doing = function() {
+        console.log('this.doing');
+        // Do nothing
+    };
+
+    this.after('initialize', function() {
+        this.on('SomeEvent', this.doing);
+    });
   }
 
   return defineComponent(Example);

--- a/test/spec/describe_component.spec.js
+++ b/test/spec/describe_component.spec.js
@@ -154,6 +154,13 @@ define(function (require) {
           this.Component.prototype.teardown.restore();
         }
       });
+      it('should do call correct function when trigger an event', function () {
+        setupComponent();
+        sinon.stub(this.component, 'doing');
+        initializeComponent();
+        $(this.$node).trigger('SomeEvent');
+        expect(this.component.doing.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/test/spec/describe_component.spec.js
+++ b/test/spec/describe_component.spec.js
@@ -1,4 +1,4 @@
-/*global describeComponent, setupComponent*/
+/*global describeComponent, setupComponent, initializeComponent*/
 
 define(function (require) {
   'use strict';
@@ -67,8 +67,10 @@ define(function (require) {
       it('should automatically call before setupComponent() if component is exists', function () {
         expect(this.component).to.equal(null);
         setupComponent();
+        initializeComponent();
         expect(this.component.teardown.callCount).to.equal(0);
         setupComponent();
+        initializeComponent();
         expect(this.component.teardown.callCount).to.equal(1);
       });
 
@@ -108,10 +110,12 @@ define(function (require) {
 
       it('should passed options to component if object givent to first argument', function () {
         setupComponent();
+        initializeComponent();
         expect(this.component.attr.param).to.equal('defaultParam');
         setupComponent({
           param: 'testParam'
         });
+        initializeComponent();
         expect(this.component.attr.param).to.equal('testParam');
       });
 
@@ -119,6 +123,7 @@ define(function (require) {
         setupComponent('<div id="test_fixture_both"/>', {
           param: 'testFixtureParam'
         });
+        initializeComponent();
         expect(this.component.attr.param).to.equal('testFixtureParam');
         expect(this.$node.hasClass('component-root')).to.be.true;
         expect(this.$node.attr('id')).to.equal('test_fixture_both');
@@ -126,10 +131,12 @@ define(function (require) {
 
       it('should reset a fixture if multiple calls', function () {
         setupComponent('<div id="fixture1"/>');
+        initializeComponent();
         expect(this.$node.hasClass('component-root')).to.be.true;
         expect(this.$node.attr('id')).to.equal('fixture1');
 
         setupComponent('<div id="fixture2"/>');
+        initializeComponent();
         expect(this.$node.hasClass('component-root')).to.be.true;
         expect(this.$node.attr('id')).to.equal('fixture2');
       });
@@ -138,8 +145,10 @@ define(function (require) {
         sinon.spy(this.Component.prototype, 'teardown');
         try {
           setupComponent();
+          initializeComponent();
           expect(this.component.teardown.callCount).to.equal(0);
           setupComponent();
+          initializeComponent();
           expect(this.component.teardown.callCount).to.equal(1);
         } finally {
           this.Component.prototype.teardown.restore();
@@ -151,6 +160,7 @@ define(function (require) {
   describeComponent('mock/other-example', function () {
     it('should support test suites for different components', function () {
       setupComponent();
+      initializeComponent();
       expect(this.Component).to.equal(OtherExample);
       expect(this.component.attr.param).to.equal('otherParam');
     });


### PR DESCRIPTION
The problem came up when i tride to stub a method then trigger event then assert if the stubbed function was calledOnce. the result was that the stubbed function was never called because the event binding was bound to the original function and not the wrapped function and that was happening in the setupComponent() 

So if you try to write the following test before applying the pull request it will fail:
```javascript
describeComponent('path/to/component', function () {
  beforeEach(function () {
    setupComponent();
  });
  it('should do x', function () {
    sinon.stub(this.component, 'method');
    $(document).trigger('EVENT_NAME');
    this.component.method.calledOnce.should.be.true;
    done();
  });
});
```
Now apply the pull request and run this:
```javascript
describeComponent('path/to/component', function () {
  beforeEach(function () {
    setupComponent();
  });
  it('should do x', function () {
    sinon.stub(this.component, 'method');
    initializeComponent();
    $(document).trigger('EVENT_NAME');
    this.component.method.calledOnce.should.be.true;
    done();
  });
});
```